### PR TITLE
Refactor product-view component and comics reducer

### DIFF
--- a/src/app/views/product-view/product-view.component.ts
+++ b/src/app/views/product-view/product-view.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Store } from '@ngrx/store';
-import { comicsFeature } from './store/comics.reducer';
+import {comicsFeature, ComicsState} from './store/comics.reducer';
 import { getComics } from './store/comics.actions';
 
 @Component({
@@ -14,9 +14,9 @@ import { getComics } from './store/comics.actions';
 export class ProductViewComponent implements OnInit {
   
   readonly comics$ = this.store.select(comicsFeature.selectAll);
-  readonly loading$ = this.store.select(comicsFeature.selectLoading);
+  readonly loading$ = this.store.select(comicsFeature.selectComicsLoading);
   
-  constructor(private store: Store) {}
+  constructor(private readonly store: Store<ComicsState>) {}
 
   ngOnInit(): void {
     this.store.dispatch(getComics());

--- a/src/app/views/product-view/services/comics.service.ts
+++ b/src/app/views/product-view/services/comics.service.ts
@@ -1,33 +1,26 @@
-import { Injectable } from '@angular/core';
-import { Observable, map, withLatestFrom } from 'rxjs';
-import { HttpClient } from '@angular/common/http';
-import { Comics } from '../../../model/Comics';
+import {Injectable} from '@angular/core';
+import {Observable, map, withLatestFrom} from 'rxjs';
+import {HttpClient} from '@angular/common/http';
+import {Comics} from '../../../model/Comics';
 
 @Injectable()
 export class ComicsService {
-  constructor(public httpClient: HttpClient) {}
+    constructor(public httpClient: HttpClient) {}
 
-  // Returns Comics without hero names
-  getProduct(): Observable<Comics[]> {
-    return this.httpClient.get<Comics[]>('/assets/data/comics.json');
-  }
+    comics$: Observable<Comics[]> = this.httpClient.get<Comics[]>('/assets/data/comics.json');
 
-  // Return map of title to heroName
-  getComicsNamesToHeroNames(): Observable<{ [title: string]: string }> {
-    return this.httpClient.get<{ [title: string]: string }>(
-      '/assets/data/hero-names.json'
+    comicsNamesToHeroNames: Observable<Record<string, string>> = this.httpClient.get<Record<string, string>>(
+        '/assets/data/hero-names.json'
     );
-  }
 
-  getComicsWithHeroNames$(): Observable<Comics[]> {
-    return this.getProduct().pipe(
-      withLatestFrom(this.getComicsNamesToHeroNames()),
-      map(([comics, heroNames]) => {
-        return comics.map((comic) => ({
-          ...comic,
-          heroName: heroNames[comic.title],
-        }));
-      })
+    comicsWithHeroNames$: Observable<Comics[]> = this.comics$.pipe(
+        withLatestFrom(this.comicsNamesToHeroNames),
+        map(([comics, heroNames]) =>
+            comics.map((comic) => ({
+                ...comic,
+                heroName: heroNames[comic.title],
+            }))
+        )
     );
-  }
+
 }

--- a/src/app/views/product-view/store/comics.effects.ts
+++ b/src/app/views/product-view/store/comics.effects.ts
@@ -14,7 +14,7 @@ export class ComicsEffects {
   loadComics$ = createEffect(() =>
     this.actions$.pipe(
       ofType(getComics),
-      mergeMap(() => this.comicsService.getComicsWithHeroNames$()),
+      mergeMap(() => this.comicsService.comicsWithHeroNames$),
       map((comics) => getComicsSuccess({ comics }))
     )
   );

--- a/src/app/views/product-view/store/comics.reducer.ts
+++ b/src/app/views/product-view/store/comics.reducer.ts
@@ -1,5 +1,5 @@
 import { createEntityAdapter, EntityState } from '@ngrx/entity';
-import { createFeature, createReducer, createSelector, on } from '@ngrx/store';
+import { createFeature, createReducer, on } from '@ngrx/store';
 import { getComics, getComicsSuccess } from './comics.actions';
 import { Comics } from '../../../model/Comics';
 
@@ -29,9 +29,5 @@ export const comicsFeature = createFeature({
   ),
   extraSelectors: ({ selectComicsState }) => ({
     ...comicsAdapter.getSelectors(selectComicsState),
-    selectLoading: createSelector(
-      selectComicsState,
-      (comicsState) => comicsState.comicsLoading
-    ),
   }),
 });


### PR DESCRIPTION
The product-view component was updated to import `ComicsState` from `comics.reducer` and replace `comicsFeature.selectLoading` with `comicsFeature.selectComicsLoading`. The constructor now uses `ComicsState` for `store`. Additionally, `selectLoading` has been removed from the `comics.reducer` file.